### PR TITLE
Fix TCP communications between Ground and Satellite systems

### DIFF
--- a/common/BaseApp.py
+++ b/common/BaseApp.py
@@ -30,7 +30,7 @@ class BaseApp():
         self.command_queue = []
         self.telemetry_queue = []
 
-        self.__startup_group = "224.1.1.90"
+        self.__startup_group = "224.1.1.92" # "224.1.1.90" Ensure system and each message queue have unqiue addresses if running all virtual
         self.__startup_port = 5090
         self.__command_group = None
         self.__command_port = None

--- a/common/TCPClient.py
+++ b/common/TCPClient.py
@@ -24,7 +24,7 @@ class TCPClient():
 
     def connect(self) -> None:
         try:
-            self.client = socket.socket(socket.AF_INET, socket.SOCK_STREAM
+            self.client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self.client.connect(self.address) 
             msg = message_pb2.Message()
             self.send(msg)  # Allows the server to store the name of this client

--- a/common/TCPClient.py
+++ b/common/TCPClient.py
@@ -24,8 +24,8 @@ class TCPClient():
 
     def connect(self) -> None:
         try:
-            self.client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            self.client.connect(self.address)
+            self.client = socket.socket(socket.AF_INET, socket.SOCK_STREAM
+            self.client.connect(self.address) 
             msg = message_pb2.Message()
             self.send(msg)  # Allows the server to store the name of this client
             thread = threading.Thread(target=self.__receive)
@@ -70,10 +70,10 @@ class TCPClient():
             buf.append(self.message_queue.get())
         return buf
 
-
-if __name__ == "__main__":
-    client = TCPClient(ip="127.0.0.1", port=5051, sender="autonomy")
-    client.start()
+# Under construction - doesn't seem to work
+if __name__ == "__main__": # runs for testing only and by running TCPClient.py directly (i.e, >> pythonTCPClient.py)
+    client = TCPClient(ip="192.168.1.160", port=5051, sender="autonomy") # Use IP address and port of the TCPServer (on Ground System)
+    client.connect()
     msg = message_pb2.Message()
     client.send(msg=msg, dst="hal")
     while client.active:

--- a/common/UDPClient.py
+++ b/common/UDPClient.py
@@ -101,15 +101,15 @@ class UDPClient():
         return None
 
 
-if __name__ == "__main__":
+if __name__ == "__main__": # runs for testing only and by running UDPClient.py directly (i.e, >> python UDPClient.py)
     print("[UDP Client] starting up...")
     client = UDPClient(id="UDPClientTest")
-    client.add_listener(group="224.1.1.1", port=5050)
+    client.add_listener(group="224.1.1.11", port=5050) # arbitrary address to test, ensure other UDP client uses same address so they talk to each other
     time.sleep(2)
-    client.add_sender(group="224.1.1.1", port=5050)
+    client.add_sender(group="224.1.1.11", port=5050)
     msg = proto.Message()
-    client.send(msg, group="224.1.1.1", port=5050)
+    client.send(msg, group="224.1.1.11", port=5050)
     while True:
-        messages = client.get_messages(group="224.1.1.1", port=5050)
+        messages = client.get_messages(group="224.1.1.11", port=5050)
         for msg in messages:
             print(f"Message: {msg}")

--- a/ground_system/cloud_service/requirements.txt
+++ b/ground_system/cloud_service/requirements.txt
@@ -1,3 +1,3 @@
-protobuf
+protobuf==3.20.*
 awscli
 boto3

--- a/ground_system/hal_service/requirements.txt
+++ b/ground_system/hal_service/requirements.txt
@@ -1,3 +1,3 @@
 RPi.GPIO
 pyserial
-protobuf
+protobuf==3.20.*

--- a/ground_system/sdr_app/requirements.txt
+++ b/ground_system/sdr_app/requirements.txt
@@ -1,1 +1,1 @@
-protobuf
+protobuf==3.20.*

--- a/satellite_system/hal_service/requirements.txt
+++ b/satellite_system/hal_service/requirements.txt
@@ -1,3 +1,3 @@
 RPi.GPIO
 pyserial
-protobuf
+protobuf==3.20.*

--- a/satellite_system/logger_service/requirements.txt
+++ b/satellite_system/logger_service/requirements.txt
@@ -1,1 +1,1 @@
-protobuf
+protobuf==3.20.*

--- a/satellite_system/main_service/config.yaml
+++ b/satellite_system/main_service/config.yaml
@@ -12,7 +12,7 @@
   telemetry_multicast_port: 5060
 
   # ---- sdr_app ----
-  sdr_tcp_client_ip: "127.0.0.1"
+  sdr_tcp_client_ip: "192.168.1.160" # modify to match the IP address of Ground System
   sdr_tcp_client_port: 5005
 
   # ---- hal_service ----

--- a/satellite_system/main_service/main_service.py
+++ b/satellite_system/main_service/main_service.py
@@ -10,7 +10,7 @@ import config_pb2
 import time
 import subprocess
 
-STARTUP_IP = "224.1.1.90"
+STARTUP_IP = "224.1.1.92" #"224.1.1.90"
 STARTUP_PORT = 5090
 
 

--- a/satellite_system/main_service/requirements.txt
+++ b/satellite_system/main_service/requirements.txt
@@ -1,2 +1,2 @@
-protobuf
+protobuf==3.20.*
 pyyaml

--- a/satellite_system/sdr_app/requirements.txt
+++ b/satellite_system/sdr_app/requirements.txt
@@ -1,1 +1,1 @@
-protobuf
+protobuf==3.20.*


### PR DESCRIPTION
To run the containers all on VMs (ground vm, satellite vm), run the build for ground, then update the startup IP in common/BaseApp.py, then run the build for satellite. More details in the Teams channel post on 10/6 in Digital Architecture channel.